### PR TITLE
Add colour input from text (hex)

### DIFF
--- a/src/ColorUtils.js
+++ b/src/ColorUtils.js
@@ -56,3 +56,68 @@ export function hslToHex(h, s, l) {
   const [r, g, b] = rgb;
   return rgbToHex(r, g, b);
 }
+
+export function hexToRgb(hex) {
+  // Source: https://css-tricks.com/converting-color-spaces-in-javascript/
+
+  let r = 0, g = 0, b = 0;
+
+  if (hex.length == 4) {
+    r = "0x" + hex[1] + hex[1];
+    g = "0x" + hex[2] + hex[2];
+    b = "0x" + hex[3] + hex[3];
+  } else if (hex.length == 7) {
+    r = "0x" + hex[1] + hex[2];
+    g = "0x" + hex[3] + hex[4];
+    b = "0x" + hex[5] + hex[6];
+  }
+
+  return [r, g, b];
+}
+
+export function hexToHsl(hex) {
+  // Source: https://css-tricks.com/converting-color-spaces-in-javascript/
+
+  let [r, g, b] = hexToRgb(hex);
+
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  let cmin = Math.min(r,g,b);
+  let cmax = Math.max(r,g,b);
+  let delta = cmax - cmin;
+  let h = 0;
+  let s = 0;
+  let l = 0;
+
+  if (delta == 0) {
+    h = 0;
+  }
+  else if (cmax == r) {
+    h = ((g - b) / delta) % 6;
+  }
+  else if (cmax == g) {
+    h = (b - r) / delta + 2;
+  }
+  else {
+    h = (r - g) / delta + 4;
+  }
+
+  h = Math.round(h * 60);
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  l = (cmax + cmin) / 2;
+  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  s = +(s * 100).toFixed(1);
+  l = +(l * 100).toFixed(1);
+
+  return [h, s, l];
+}
+
+export function isValidHex(hex) {
+  return /^#?[\da-f]{3}(?:[\da-f]{3})?$/gi.test(hex);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -146,11 +146,17 @@ a {
   font-weight: 600;
 }
 
-.control-header button.hex {
-  text-transform: uppercase;
+.control-header .selector-input {
+  display: flex;
+  align-items: center;
 }
 
-.control-header button.hex {
+.control-header input.hex {
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.control-header input.hex {
   color: var(--text-color);
   font-size: 0.75em;
   border-color: transparent;
@@ -158,7 +164,7 @@ a {
   background-color: var(--text-color-10);
 }
 
-.control-header button.hex:hover {
+.control-header input.hex:hover {
   background-color: hsla(
     var(--text_hue),
     var(--text_saturation),
@@ -167,15 +173,33 @@ a {
   );
 }
 
-.control-header button.hex:active {
+.control-header input.hex:active {
   background-color: var(--text-color-30);
 }
 
-.control-header button.hex:focus {
+.control-header input.hex:focus {
   border-color: var(--text-color);
   border-width: 1px;
   outline: 0;
   border-style: solid;
+}
+
+.control-header .clipboard {
+  border: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+}
+
+.control-header .clipboard > svg {
+  color: var(--text-color);
+  fill: currentColor;
+  margin-left: .7rem;
+  width: 1rem;
+  height: 1rem;
 }
 
 footer {


### PR DESCRIPTION
Hi!

I found the contrast tool very useful, and would like to add the ability to input the hex values in the text fields.

## Summary

- Added `hexToHsl` and `isValidHex`. If the latter is false nothing happens; only when the hex is valid we change the colour.
- Refactor setting the `--${props.target}_{id}` properties.
- Replace the hex button with an input. To maintain the copy to clipboard feature, a button has been added next to the input.

Thank you!